### PR TITLE
update codec version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ std = [
 [dependencies.parity-codec]
 default-features = false
 features = ['derive']
-version = '3.5'
+version = '4.1.1'
 
 [dependencies.support]
 default_features = false


### PR DESCRIPTION
with codec version 3.5 I was getting this error

the trait `dao::sr_api_hidden_includes_decl_storage::hidden_include::dispatch::Decode` is not implemented for `dao::Call<T>`

Only after looking at [this issue on an unrelated project](https://github.com/jonhoo/fantoccini/issues/8) did I realize that the mistake was with the `codec` itself and the error went away after I updated to version 4.1.1